### PR TITLE
Alias for Vector2u should use the UInt32 type

### DIFF
--- a/src/system/system.cr
+++ b/src/system/system.cr
@@ -135,7 +135,7 @@ module SF
   end
 
   alias Vector2i = Vector2(Int32)
-  alias Vector2u = Vector2i
+  alias Vector2u = Vector2(UInt32)
   alias Vector2f = Vector2(Float32)
 
   # Shorthand for `Vector2f.new`


### PR DESCRIPTION
When trying to change the size of a `SF::RenderWindow` I was getting the following error.

![Screen Shot 2021-04-06 at 12 47 33 AM](https://user-images.githubusercontent.com/7513070/113660284-bd84cd00-9671-11eb-8c25-e00bf912c354.png)

After making this change locally, I was able to resize the window.

Minimal amount of code to reproduce the error
```
require "crsfml"

window = SF::RenderWindow.new(SF::VideoMode.new(1440, 810), "CRSFML")
window.size = { 400, 400 }

while window.open?
  while event = window.poll_event
    if event.is_a? SF::Event::Closed
      window.close
    end
  end

  window.display
end
```