### PR TITLE
Allow examples to be run from outside examples/

### DIFF
--- a/examples/diagnostics.cr
+++ b/examples/diagnostics.cr
@@ -3,8 +3,7 @@ require "crsfml"
 require "crsfml/audio"
 require "./text_input"
 
-
-FONT = SF::Font.from_file("resources/font/Cantarell-Regular.otf")
+FONT = SF::Font.from_file("#{__DIR__}/resources/font/Cantarell-Regular.otf")
 
 module Color
   BLACK = SF::Color::Black
@@ -120,7 +119,7 @@ class KeyboardView < View
     margin = SF.vector2f(0.1, 0.1)
     @outline_thickness = (3 ** (scale / zoom)).round.to_i
 
-    yaml = YAML.parse(File.read("resources/keyboard-layout.yaml"))
+    yaml = YAML.parse(File.read("#{__DIR__}/resources/keyboard-layout.yaml"))
     y = margin.y * 3
     yaml.as_a.each do |line|
       x = margin.x * 3

--- a/examples/flippy_bird.cr
+++ b/examples/flippy_bird.cr
@@ -5,7 +5,7 @@ mode = SF::VideoMode.new(800, 600)
 window = SF::RenderWindow.new(mode, "pɹıq ʎddılɟ")
 window.vertical_sync_enabled = true
 
-bird_texture = SF::Texture.from_file("resources/bird.png")
+bird_texture = SF::Texture.from_file("#{__DIR__}/resources/bird.png")
 
 bird = SF::Sprite.new(bird_texture)
 bird.origin = bird_texture.size / 2.0

--- a/examples/shader.cr
+++ b/examples/shader.cr
@@ -4,7 +4,7 @@
 require "crsfml"
 require "crsfml/network"
 
-FONT = SF::Font.from_file("resources/font/Cantarell-Regular.otf")
+FONT = SF::Font.from_file("#{__DIR__}/resources/font/Cantarell-Regular.otf")
 
 def mouse_pos(window)
   cursor = SF::Mouse.get_position(window)
@@ -12,11 +12,11 @@ def mouse_pos(window)
 end
 
 class Scene1
-  BACKGROUND_TEXTURE = SF::Texture.from_file("resources/background.jpg")
+  BACKGROUND_TEXTURE = SF::Texture.from_file("#{__DIR__}/resources/background.jpg")
 
   def initialize
     @sprite = SF::Sprite.new(BACKGROUND_TEXTURE)
-    @shader = SF::Shader.from_file("resources/shaders/pixelate.frag", SF::Shader::Fragment)
+    @shader = SF::Shader.from_file("#{__DIR__}/resources/shaders/pixelate.frag", SF::Shader::Fragment)
     @shader.texture SF::Shader::CurrentTexture
   end
 
@@ -41,7 +41,7 @@ class Scene2
     @text.position = {30, 20}
     @text.color = SF::Color::Black
 
-    @shader = SF::Shader.from_file("resources/shaders/wave.vert", "resources/shaders/blur.frag")
+    @shader = SF::Shader.from_file("#{__DIR__}/resources/shaders/wave.vert", "#{__DIR__}/resources/shaders/blur.frag")
     @clock = SF::Clock.new
   end
 

--- a/examples/text_input.cr
+++ b/examples/text_input.cr
@@ -360,7 +360,7 @@ end
 
 def main()  # A hack to allow the code above to be reused: `require` and override `main`
   window = SF::RenderWindow.new(SF::VideoMode.new(800, 600), "Typing")
-  text = TypingWidget.new(SF::Font.from_file("resources/font/Cantarell-Regular.otf"), 24)
+  text = TypingWidget.new(SF::Font.from_file("#{__DIR__}/resources/font/Cantarell-Regular.otf"), 24)
 
   while window.open?
     while event = window.poll_event

--- a/examples/transformable.cr
+++ b/examples/transformable.cr
@@ -1,7 +1,6 @@
 require "crsfml"
 
-
-FONT = SF::Font.from_file("resources/font/Cantarell-Regular.otf")
+FONT = SF::Font.from_file("#{__DIR__}/resources/font/Cantarell-Regular.otf")
 
 struct SF::Rect
   def center


### PR DESCRIPTION
This will only work if there's a lib/ directory where you're running it that contains crsfml, but that's okay for the primary use case where a user runs examples from a project that depends on crsfml.