### PR TITLE
Fix TileMap code in vertex tutorial

### DIFF
--- a/docs/tutorials/graphics/vertex-array.md
+++ b/docs/tutorials/graphics/vertex-array.md
@@ -215,7 +215,7 @@ class TileMap < SF::Transformable
 
     @vertices = SF::VertexArray.new(SF::Quads)
 
-    tiles_per_row = @tileset.size.x / tile_size.x
+    tiles_per_row = @tileset.size.x // tile_size.x
 
     # populate the vertex array, with one quad per tile
     (0...height).each do |y|
@@ -226,7 +226,7 @@ class TileMap < SF::Transformable
         # find its position in the tileset texture
         tile_pos = SF.vector2(
           tile_index % tiles_per_row,
-          tile_index / tiles_per_row
+          tile_index // tiles_per_row
         )
 
         destination = SF.vector2(x, y)


### PR DESCRIPTION
Division between 2 integers return float values after this update:
https://github.com/crystal-lang/crystal/pull/8120

I couldn't run the tutorial and render it properly without tweaking it to use the floor division operator.
Thank you for CrSFML!